### PR TITLE
Adds torch 2.6 to index

### DIFF
--- a/cu118/index.html
+++ b/cu118/index.html
@@ -5,3 +5,4 @@
 <a href="torch2.3">torch 2.3.*</a><br>
 <a href="torch2.4">torch 2.4.*</a><br>
 <a href="torch2.5">torch 2.5.*</a><br>
+<a href="torch2.6">torch 2.6.*</a><br>

--- a/cu124/index.html
+++ b/cu124/index.html
@@ -2,3 +2,4 @@
 <h1>FlashInfer Python Wheels for CUDA 12.4</h1>
 <a href="torch2.4">torch 2.4.*</a><br>
 <a href="torch2.5">torch 2.5.*</a><br>
+<a href="torch2.6">torch 2.6.*</a><br>


### PR DESCRIPTION
These wheels exist but not in the index:

- https://github.com/flashinfer-ai/whl/blob/gh-pages/cu118/torch2.6/flashinfer-python/index.html
- https://github.com/flashinfer-ai/whl/blob/gh-pages/cu124/torch2.6/flashinfer-python/index.html

